### PR TITLE
[patch-axel-6] CI: cancel older concurrent PR runs

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -6,7 +6,7 @@
 #
 # See sel4test-hw/builds.yml in the repo seL4/ci-actions for configs.
 
-name: seL4Test HW
+name: seL4Test-HW
 
 on:
   # needs PR target for secrets access; guard by requiring label
@@ -16,6 +16,12 @@ on:
 # downgrade permissions to read-only as you would have in a standard PR action
 permissions:
   contents: read
+
+# Cancel older runs of this workflow that are still not finished for the
+# current PR. This reduces the CI load.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   hw-build:

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -13,6 +13,13 @@ on:
     branches: [master]
   pull_request:
 
+# Cancel older runs of this workflow that are still not finished for the
+# current PR. This reduces the CI load. For deployment to the master branch,
+# the workflow will run on each push, but no cancellation happens here.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   simulation:
     name: Simulation


### PR DESCRIPTION
Remove the space in the workflow name to ensure there are no side effects when using it as an identifier.